### PR TITLE
Handle int64 as string with format

### DIFF
--- a/examples/tests/mapfields/openapi.yaml
+++ b/examples/tests/mapfields/openapi.yaml
@@ -42,8 +42,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         GoogleProtobufAny:
@@ -91,8 +90,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/mapfields/openapi_default_response.yaml
+++ b/examples/tests/mapfields/openapi_default_response.yaml
@@ -42,8 +42,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         GoogleProtobufAny:
@@ -91,8 +90,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/mapfields/openapi_fq_schema_naming.yaml
+++ b/examples/tests/mapfields/openapi_fq_schema_naming.yaml
@@ -66,8 +66,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         tests.mapfields.message.v1.Message:
@@ -107,8 +106,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
 tags:

--- a/examples/tests/mapfields/openapi_json.yaml
+++ b/examples/tests/mapfields/openapi_json.yaml
@@ -42,8 +42,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         GoogleProtobufAny:
@@ -91,8 +90,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/mapfields/openapi_string_enum.yaml
+++ b/examples/tests/mapfields/openapi_string_enum.yaml
@@ -42,8 +42,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         GoogleProtobufAny:
@@ -91,8 +90,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/noannotations/openapi.yaml
+++ b/examples/tests/noannotations/openapi.yaml
@@ -50,8 +50,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/noannotations/openapi_default_response.yaml
+++ b/examples/tests/noannotations/openapi_default_response.yaml
@@ -50,8 +50,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/noannotations/openapi_fq_schema_naming.yaml
+++ b/examples/tests/noannotations/openapi_fq_schema_naming.yaml
@@ -66,8 +66,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
 tags:

--- a/examples/tests/noannotations/openapi_json.yaml
+++ b/examples/tests/noannotations/openapi_json.yaml
@@ -50,8 +50,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/noannotations/openapi_string_enum.yaml
+++ b/examples/tests/noannotations/openapi_string_enum.yaml
@@ -50,8 +50,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     type: string
         Status:

--- a/examples/tests/openapiv3annotations/openapi.yaml
+++ b/examples/tests/openapiv3annotations/openapi.yaml
@@ -61,8 +61,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/examples/tests/openapiv3annotations/openapi_default_response.yaml
+++ b/examples/tests/openapiv3annotations/openapi_default_response.yaml
@@ -61,8 +61,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
+++ b/examples/tests/openapiv3annotations/openapi_fq_schema_naming.yaml
@@ -77,8 +77,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/examples/tests/openapiv3annotations/openapi_json.yaml
+++ b/examples/tests/openapiv3annotations/openapi_json.yaml
@@ -61,8 +61,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/examples/tests/openapiv3annotations/openapi_string_enum.yaml
+++ b/examples/tests/openapiv3annotations/openapi_string_enum.yaml
@@ -61,8 +61,7 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int64
+                    type: string
                 label:
                     title: this is an overriden field schema title
                     maxLength: 255

--- a/examples/tests/pathparams/openapi.yaml
+++ b/examples/tests/pathparams/openapi.yaml
@@ -20,8 +20,7 @@ paths:
                 - name: user_id
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
             responses:
                 "200":
                     description: OK
@@ -74,8 +73,7 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: message_id
                   in: path
                   required: true
@@ -110,8 +108,7 @@ components:
                 message_id:
                     type: string
                 user_id:
-                    type: integer
-                    format: uint64
+                    type: string
                 content:
                     type: string
                 maybe:

--- a/examples/tests/pathparams/openapi_default_response.yaml
+++ b/examples/tests/pathparams/openapi_default_response.yaml
@@ -20,8 +20,7 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
             responses:
                 "200":
                     description: OK
@@ -74,8 +73,7 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: messageId
                   in: path
                   required: true
@@ -110,8 +108,7 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: integer
-                    format: uint64
+                    type: string
                 content:
                     type: string
                 maybe:

--- a/examples/tests/pathparams/openapi_fq_schema_naming.yaml
+++ b/examples/tests/pathparams/openapi_fq_schema_naming.yaml
@@ -20,8 +20,7 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
             responses:
                 "200":
                     description: OK
@@ -74,8 +73,7 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: messageId
                   in: path
                   required: true
@@ -126,8 +124,7 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: integer
-                    format: uint64
+                    type: string
                 content:
                     type: string
                 maybe:

--- a/examples/tests/pathparams/openapi_json.yaml
+++ b/examples/tests/pathparams/openapi_json.yaml
@@ -20,8 +20,7 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
             responses:
                 "200":
                     description: OK
@@ -74,8 +73,7 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: messageId
                   in: path
                   required: true
@@ -110,8 +108,7 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: integer
-                    format: uint64
+                    type: string
                 content:
                     type: string
                 maybe:

--- a/examples/tests/pathparams/openapi_string_enum.yaml
+++ b/examples/tests/pathparams/openapi_string_enum.yaml
@@ -20,8 +20,7 @@ paths:
                 - name: userId
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
             responses:
                 "200":
                     description: OK
@@ -74,8 +73,7 @@ paths:
                   in: path
                   required: true
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: messageId
                   in: path
                   required: true
@@ -110,8 +108,7 @@ components:
                 messageId:
                     type: string
                 userId:
-                    type: integer
-                    format: uint64
+                    type: string
                 content:
                     type: string
                 maybe:

--- a/examples/tests/protobuftypes/openapi.yaml
+++ b/examples/tests/protobuftypes/openapi.yaml
@@ -124,13 +124,11 @@ paths:
                 - name: int64_value_type
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64_value_type
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: float_value_type
                   in: query
                   schema:
@@ -291,13 +289,11 @@ paths:
                 - name: int64_value_type
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64_value_type
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: float_value_type
                   in: query
                   schema:

--- a/examples/tests/protobuftypes/openapi_default_response.yaml
+++ b/examples/tests/protobuftypes/openapi_default_response.yaml
@@ -124,13 +124,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:
@@ -291,13 +289,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:

--- a/examples/tests/protobuftypes/openapi_fq_schema_naming.yaml
+++ b/examples/tests/protobuftypes/openapi_fq_schema_naming.yaml
@@ -124,13 +124,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:
@@ -291,13 +289,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:

--- a/examples/tests/protobuftypes/openapi_json.yaml
+++ b/examples/tests/protobuftypes/openapi_json.yaml
@@ -124,13 +124,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:
@@ -291,13 +289,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:

--- a/examples/tests/protobuftypes/openapi_string_enum.yaml
+++ b/examples/tests/protobuftypes/openapi_string_enum.yaml
@@ -124,13 +124,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:
@@ -291,13 +289,11 @@ paths:
                 - name: int64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: int64
+                    type: string
                 - name: uint64ValueType
                   in: query
                   schema:
-                    type: integer
-                    format: uint64
+                    type: string
                 - name: floatValueType
                   in: query
                   schema:

--- a/generator/reflector.go
+++ b/generator/reflector.go
@@ -233,10 +233,12 @@ func (r *OpenAPIv3Reflector) schemaOrReferenceForField(field protoreflect.FieldD
 		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Uint32Kind,
-		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
-		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind,
-		protoreflect.Fixed64Kind:
+		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind:
 		kindSchema = wk.NewIntegerSchema(kind.String())
+
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
+		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
+		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.EnumKind:
 		kindSchema = wk.NewEnumSchema(*&r.conf.EnumType, field)


### PR DESCRIPTION
context:
- https://github.com/grpc-ecosystem/grpc-gateway/issues/438
- https://github.com/golang/protobuf/issues/1414
- https://github.com/OpenAPITools/openapi-generator-cli

Originally, this was changed so that int64 fields would be written to
the openapi spec as integer types which is supported by the OpenAPI
spec. However, jsonpb and other related projects have chosen to enforce
that int64 fields are written as strings. This is because JavaScript
represents integers as 32 bit numbers and if you pass it a value that is
outside of that range it will overflow. Since we are using jsonpb to
transform the protos to json, we need to make sure that the generated
schema is consistent with the jsonpb behavior.
